### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 # **本仓库只做高性价比机场的使用后推荐，适合小白或者给查资料学术研究的人使用**
 # **任何机场均有跑路风险，请购买机场时优先月付避免机场后期跑路危机！**
 ### 序言


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search, and it's open source project, we can change web or local file mode.

The updated links can be previewed in my forked repository: https://github.com/openaitx-system/MagicInternet/tree/Auto_translate_README_and_Wiki

Demo links : 
- [Español](https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=es)
- [简体中文](https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=ko)
- [Français](https://openaitx.github.io/view.html?user=Magic4536251&project=MagicInternet&lang=fr)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962  " />

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌
